### PR TITLE
Clean up the "name" key from the test script

### DIFF
--- a/kv-test
+++ b/kv-test
@@ -91,6 +91,7 @@ TESTCASE 'spaces in value'
 	kvset name '  phat  dam  '
 	[ "$(kvget name)" == '  phat  dam  ' ]
 	RESULT
+	kvdel name
 	
 #more testcase here
 


### PR DESCRIPTION
This is just a single line change that cleans up the name == '  phat  dam ' test case data.  After I ran kv-test this value was still in there so I figured I would remove it.  I don't know if adding the `kvdel` call after `RESULT` will break anything but it didn't look like it would.