### PR TITLE
Add the ability to use bash variables when setting keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,4 +73,6 @@ RUN ALL TEST CASES:
  11 kvclear; kvlist => line count = 0                 [  OK  ]
  12 kvget return empty value => error code != 0       [  OK  ]
  13 spaces in value                                   [  OK  ]
+ 14 spaces in value with substitution                 [  OK  ]
+ 15 spaces in value without quotes                    [  OK  ]
 ```

--- a/kv-bash
+++ b/kv-bash
@@ -110,13 +110,13 @@ kvget() {
 # Usage: kvset <key> [value] 
 kvset() {
 	key="$1"
-	value="$2"
+	value="${@:2}"
 	kv_validate_key "$key" || {
 		kv_echo_err_box 'invalid param "key"' 'kvset()'
 		return 1
 	}
 	test -d "$KV_USER_DIR" || mkdir "$KV_USER_DIR"
-	echo "$value" > "$KV_USER_DIR/$key"
+	echo "${value[@]}" > "$KV_USER_DIR/$key"
 }
 
 # Usage: kvdel <key>

--- a/kv-test
+++ b/kv-test
@@ -92,7 +92,21 @@ TESTCASE 'spaces in value'
 	[ "$(kvget name)" == '  phat  dam  ' ]
 	RESULT
 	kvdel name
-	
+
+TESTCASE 'spaces in value with substitution'
+	test="fizz buzz"
+	kvset name "foo bar $test"
+	[ "$(kvget name)" == "foo bar fizz buzz" ]
+	RESULT
+	kvdel name
+
+TESTCASE 'spaces in value without quotes'
+	test="fizz buzz"
+	kvset name foo bar $test
+	[ "$(kvget name)" == "foo bar fizz buzz" ]
+	RESULT
+	kvdel name
+
 #more testcase here
 
 echo


### PR DESCRIPTION
Now we can run
```
$ test="a b c"
$ kvset key 1 2 3 4 $test
$ kvget key
> 1 2 3 4 a b c
```
This is very helpful when using kv-bash for storing arrays.