### PR TITLE
Addeded a test case for testing kvclear with default/no KV_USER_DIR

### DIFF
--- a/kv-test
+++ b/kv-test
@@ -10,7 +10,6 @@ RESULT()  { [ $? == 0 ] && OK || FAILED; }
 TEST_COUNT=0
 test_dirA="./testingdirA"
 test_dirB="./testingdirB"
-KV_USER_DIR="$test_dirA"
 
 # Usage: TESTCASE [description string]
 function TESTCASE() {
@@ -23,6 +22,15 @@ rm -rf "$test_dirA" "$test_dirB"
 echo
 echo RUN ALL TEST CASES:
 echo ===================
+
+TESTCASE 'NO KV_USER_DIR: kvclear; kvlist => line count = 0'
+        kvset cat Tom
+        kvset mouse Jerry
+        kvclear
+        [ $(kvlist | wc -l) == 0 ]
+        RESULT
+
+KV_USER_DIR="$test_dirA"
 
 TESTCASE 'call kvget for non-exist key should return empty'
 	[ "$(kvget name)" == "" ]


### PR DESCRIPTION
This test fails but that is actually correct because commit https://github.com/damphat/kv-bash/commit/f0936e12eb85bc8448a7b2e810ebae77f2e64592 introduced a bug not covered with the current test.