### PR TITLE
Bug fix: dysfunctional kvclear when no/default KV_USER_DIR

### DIFF
--- a/kv-bash
+++ b/kv-bash
@@ -149,5 +149,6 @@ kvlist() {
 # clear all key/value pairs in database
 # Usage: kvclear
 kvclear() {
-	rm -rf "$KV_USER_DIR"
+        kv_user_dir=${KV_USER_DIR:-$default_kv_user_dir}
+	rm -rf "$kv_user_dir"
 }


### PR DESCRIPTION
This PR fixes a bug in  commit https://github.com/damphat/kv-bash/commit/f0936e12eb85bc8448a7b2e810ebae77f2e64592: kvclear is not working when there is no/default KV_USER_DIR set.

PR https://github.com/damphat/kv-bash/pull/13 adds the test case to verify this fix. I suggest to merge PR https://github.com/damphat/kv-bash/pull/13 first, see the failing test and then merge this PR which should make the test finally pass.